### PR TITLE
docs(reference): migrate newDefinedName to FWorkbook.newDefinedNameBuilder

### DIFF
--- a/content/reference/facade/defined-name.mdx
+++ b/content/reference/facade/defined-name.mdx
@@ -53,12 +53,12 @@ build(): ISetDefinedNameMutationParam
 **Examples**
 ```ts
 const fWorkbook = univerAPI.getActiveWorkbook();
-const definedNameBuilder = univerAPI.newDefinedName()
+const definedNameParam = fWorkbook.newDefinedNameBuilder()
   .setName('MyDefinedName')
   .setRef('Sheet1!$A$1')
   .setComment('A reference to A1 cell in Sheet1')
   .build();
-fWorkbook.insertDefinedNameBuilder(definedNameBuilder);
+fWorkbook.insertDefinedNameBuilder(definedNameParam);
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
@@ -190,12 +190,12 @@ setComment(comment: string): FDefinedNameBuilder
 **Examples**
 ```ts
 const fWorkbook = univerAPI.getActiveWorkbook();
-const definedNameBuilder = univerAPI.newDefinedName()
+const definedNameParam = fWorkbook.newDefinedNameBuilder()
   .setName('MyDefinedName')
   .setRef('Sheet1!$A$1')
   .setComment('A reference to A1 cell in Sheet1')
   .build();
-fWorkbook.insertDefinedNameBuilder(definedNameBuilder);
+fWorkbook.insertDefinedNameBuilder(definedNameParam);
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
@@ -218,11 +218,11 @@ setFormula(formula: string): FDefinedNameBuilder
 **Examples**
 ```ts
 const fWorkbook = univerAPI.getActiveWorkbook();
-const definedNameBuilder = univerAPI.newDefinedName()
+const definedNameParam = fWorkbook.newDefinedNameBuilder()
   .setName('MyDefinedName')
   .setFormula('SUM(Sheet1!$A$1)')
   .build();
-fWorkbook.insertDefinedNameBuilder(definedNameBuilder);
+fWorkbook.insertDefinedNameBuilder(definedNameParam);
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
@@ -245,12 +245,12 @@ setHidden(hidden: boolean): FDefinedNameBuilder
 **Examples**
 ```ts
 const fWorkbook = univerAPI.getActiveWorkbook();
-const definedNameBuilder = univerAPI.newDefinedName()
+const definedNameParam = fWorkbook.newDefinedNameBuilder()
   .setName('MyDefinedName')
   .setRef('Sheet1!$A$1')
   .setHidden(true)
   .build();
-fWorkbook.insertDefinedNameBuilder(definedNameBuilder);
+fWorkbook.insertDefinedNameBuilder(definedNameParam);
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
@@ -273,11 +273,11 @@ setName(name: string): FDefinedNameBuilder
 **Examples**
 ```ts
 const fWorkbook = univerAPI.getActiveWorkbook();
-const definedNameBuilder = univerAPI.newDefinedName()
+const definedNameParam = fWorkbook.newDefinedNameBuilder()
   .setName('MyDefinedName')
   .setRef('Sheet1!$A$1')
   .build();
-fWorkbook.insertDefinedNameBuilder(definedNameBuilder);
+fWorkbook.insertDefinedNameBuilder(definedNameParam);
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
@@ -300,11 +300,11 @@ setRef(a1Notation: string): FDefinedNameBuilder
 **Examples**
 ```ts
 const fWorkbook = univerAPI.getActiveWorkbook();
-const definedNameBuilder = univerAPI.newDefinedName()
+const definedNameParam = fWorkbook.newDefinedNameBuilder()
   .setName('MyDefinedName')
   .setRef('Sheet1!$A$1')
   .build();
-fWorkbook.insertDefinedNameBuilder(definedNameBuilder);
+fWorkbook.insertDefinedNameBuilder(definedNameParam);
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
@@ -330,11 +330,11 @@ setRefByRange(row: number, column: number, numRows: number, numColumns: number):
 **Examples**
 ```ts
 const fWorkbook = univerAPI.getActiveWorkbook();
-const definedNameBuilder = univerAPI.newDefinedName()
+const definedNameParam = fWorkbook.newDefinedNameBuilder()
   .setName('MyDefinedName')
   .setRefByRange(1, 3, 2, 5) // D2:H3
   .build();
-fWorkbook.insertDefinedNameBuilder(definedNameBuilder);
+fWorkbook.insertDefinedNameBuilder(definedNameParam);
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
@@ -421,16 +421,14 @@ load(param: ISetDefinedNameMutationParam): FDefinedNameBuilder
 **Examples**
 ```ts
 const fWorkbook = univerAPI.getActiveWorkbook();
-const definedNameParam = {
-  id: '4TMPceoqg8',
-  unitId: fWorkbook.getId(),
-  name: 'MyDefinedName',
-  formulaOrRefString: 'Sheet1!$A$1',
-}
-const definedNameBuilder = univerAPI.newDefinedName()
-  .load(definedNameParam)
+const definedNameParam = fWorkbook.newDefinedNameBuilder()
+  .load({
+    id: '4TMPceoqg8',
+    name: 'MyDefinedName',
+    formulaOrRefString: 'Sheet1!$A$1',
+  })
   .build();
-fWorkbook.insertDefinedNameBuilder(definedNameBuilder);
+fWorkbook.insertDefinedNameBuilder(definedNameParam);
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
@@ -452,12 +450,12 @@ toBuilder(): FDefinedNameBuilder
 const fWorkbook = univerAPI.getActiveWorkbook();
 const definedName = fWorkbook.getDefinedNames()[0];
 if (!definedName) return;
-const definedNameBuilder = definedName
+const definedNameParam = definedName
   .toBuilder()
   .setName('NewDefinedName')
   .setFormula('SUM(Sheet1!$A$1)')
   .build();
-fWorkbook.updateDefinedNameBuilder(definedNameBuilder);
+fWorkbook.updateDefinedNameBuilder(definedNameParam);
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>

--- a/content/reference/facade/univer.mdx
+++ b/content/reference/facade/univer.mdx
@@ -80,7 +80,6 @@ to create a new instance.
 | [`getSheetTarget`](#getsheettarget) | - |
 | [`getUniverSheet`](#getuniversheet) | - |
 | [`getWorkbook`](#getworkbook) | - |
-| [`newDefinedName`](#newdefinedname) | - |
 | [`onUniverSheetCreated`](#onuniversheetcreated) | - |
 | [`setFreezeSync`](#setfreezesync) | - |
 
@@ -616,18 +615,6 @@ static newDataValidation(): FDataValidationBuilder
 - `FDataValidationBuilder` — A new instance of the FDataValidationBuilder class
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets-data-validation`</span>
-
-### `newDefinedName`
-
-**Signature**
-```typescript
-newDefinedName(): FDefinedNameBuilder
-```
-
-**Returns**
-- `FDefinedNameBuilder` — See signature above.
-
-<span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
 
 ### `newParagraphStyle`
 

--- a/content/reference/facade/workbook.mdx
+++ b/content/reference/facade/workbook.mdx
@@ -51,6 +51,7 @@ Facade API object bounded to a workbook. It provides a set of methods to interac
 | [`insertSheet`](#insertsheet) | Inserts a new worksheet into the workbook |
 | [`moveActiveSheet`](#moveactivesheet) | Move the active sheet to the specified index |
 | [`moveSheet`](#movesheet) | Move the sheet to the specified index |
+| [`newDefinedNameBuilder`](#newdefinednamebuilder) | Create a new defined name builder |
 | [`onBeforeCommandExecute`](#onbeforecommandexecute) | Callback for command execution |
 | [`onCommandExecuted`](#oncommandexecuted) | Callback for command execution |
 | [`onSelectionChange`](#onselectionchange) | Callback for selection changes |
@@ -491,12 +492,38 @@ insertDefinedNameBuilder(param: ISetDefinedNameMutationParam): void
 ```ts
 // The code below inserts a defined name by builder param
 const fWorkbook = univerAPI.getActiveWorkbook();
-const definedNameBuilder = univerAPI.newDefinedName()
+const definedNameParam = fWorkbook.newDefinedNameBuilder()
   .setRef('Sheet1!$A$1')
   .setName('MyDefinedName')
   .setComment('This is a comment')
   .build();
-fWorkbook.insertDefinedNameBuilder(definedNameBuilder);
+fWorkbook.insertDefinedNameBuilder(definedNameParam);
+```
+
+<span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
+
+### `newDefinedNameBuilder`
+
+Create a new defined name builder.
+
+**Signature**
+```typescript
+newDefinedNameBuilder(): FDefinedNameBuilder
+```
+
+**Returns**
+- `FDefinedNameBuilder` — The defined name builder.
+
+**Examples**
+```ts
+const fWorkbook = univerAPI.getActiveWorkbook();
+const definedNameParam = fWorkbook.newDefinedNameBuilder()
+  .setRef('Sheet1!$A$1')
+  .setName('MyDefinedName')
+  .setComment('This is a comment')
+  .build();
+console.log(definedNameParam);
+fWorkbook.insertDefinedNameBuilder(definedNameParam);
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>
@@ -574,10 +601,6 @@ getDefinedName(name: string): FDefinedName | null
 const fWorkbook = univerAPI.getActiveWorkbook();
 const definedName = fWorkbook.getDefinedName('MyDefinedName');
 console.log(definedName?.getFormulaOrRefString());
-
-if (definedName) {
-  definedName.setName('NewDefinedName');
-}
 ```
 
 <span className="text-xs text-fd-muted-foreground">Source: `@univerjs/sheets`</span>


### PR DESCRIPTION


- Remove newDefinedName from FUniver facade API docs
- Add newDefinedNameBuilder to FWorkbook facade API docs
- Update all examples in defined-name reference to use fWorkbook.newDefinedNameBuilder()